### PR TITLE
speak: dont recognize generated messages as copypasta memes

### DIFF
--- a/command/talk.go
+++ b/command/talk.go
@@ -58,6 +58,8 @@ func speakCmd(ctx context.Context, robo *Robot, call *Invocation, effect string)
 		r.CancelAt(t)
 		return ""
 	}
+	// block the generated message from being later recognized as a meme.
+	call.Channel.Memery.Block(call.Message.Time(), s)
 	slog.InfoContext(ctx, "speak", "in", call.Channel.Name, "text", m, "emote", e)
 	return m + " " + e
 }


### PR DESCRIPTION
Adds a memery.Block call inside of speak to prevent the generated message from being recognized as a meme. 

I put the call to block after the rate limit and other checks so we only block the message if we're actually going to send the message.

to close #79 