### PR TITLE
Add initial Discord integration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ go.work
 go.work.sum
 /robot
 /robot.exe
+.idea/

--- a/discord.go
+++ b/discord.go
@@ -170,7 +170,11 @@ func (robo *Robot) onDiscordMessage(ctx context.Context, session *discordgo.Sess
 
 	// TODO: Learn from this user only if not disabled, not sure if applicable to discord
 	// TODO: Meme detector stuff, possibly not necessary in discord?
-	robo.discordLearn(ctx, ch.Learn, event)
+
+	// Empty messages could exist due to being a sticker or a file upload
+	if event.Content != "" {
+		robo.discordLearn(ctx, ch.Learn, event)
+	}
 
 	// Now we can check rate limits
 	t := time.Now()

--- a/discord.go
+++ b/discord.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/bwmarrin/discordgo"
+	"github.com/zephyrtronium/robot/brain"
+	"log/slog"
+	"math/rand/v2"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type MessageReceiver struct {
+	session *discordgo.Session
+}
+
+func (robo *Robot) NewDiscord(ctx context.Context, token string) (*MessageReceiver, error) {
+	session, err := discordgo.New("Bot " + token)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Discord session: %w", err)
+	}
+
+	receiver := &MessageReceiver{
+		session: session,
+	}
+
+	// Enable message receive intent
+	session.Identify.Intents = discordgo.IntentGuilds | discordgo.IntentGuildBans | discordgo.IntentsGuildMessages
+
+	// Register message handler
+	session.AddHandler(func(session *discordgo.Session, event *discordgo.MessageCreate) {
+		robo.onDiscordMessage(ctx, session, event)
+	})
+
+	// Register slash commands on startup
+	session.AddHandler(func(session *discordgo.Session, event *discordgo.Ready) {
+		permission := int64(discordgo.PermissionManageMessages)
+		commands := []*discordgo.ApplicationCommand{
+			{
+				Name:        "say",
+				Description: "Say something",
+				Options: []*discordgo.ApplicationCommandOption{
+					{
+						Type:        discordgo.ApplicationCommandOptionString,
+						Name:        "prompt",
+						Description: "Prompt to use for generating a message",
+						Required:    true,
+					},
+				},
+			},
+			{
+				Name:                     "forget",
+				DefaultMemberPermissions: &permission,
+				Description:              "Forget something",
+				Options: []*discordgo.ApplicationCommandOption{
+					{
+						Type:        discordgo.ApplicationCommandOptionString,
+						Name:        "prompt",
+						Description: "Prompt to search for and delete messages",
+						Required:    true,
+					},
+				},
+			},
+		}
+		// Register as global commands
+		_, err := session.ApplicationCommandBulkOverwrite(event.Application.ID, "", commands)
+		if err != nil {
+			_ = fmt.Errorf("failed to update slash commands: %w", err)
+		}
+	})
+
+	// Forget messages on deletion
+	session.AddHandler(func(session *discordgo.Session, event *discordgo.MessageDelete) {
+		ch, _ := robo.channels.Load(event.GuildID)
+		if ch == nil {
+			return
+		}
+		err := robo.brain.Forget(ctx, ch.Learn, event.Message.ID)
+		if err != nil {
+			_ = fmt.Errorf("failed to delete message: %w", err)
+		}
+	})
+
+	// Handle slash commands
+	session.AddHandler(func(session *discordgo.Session, event *discordgo.InteractionCreate) {
+		if event.Type != discordgo.InteractionApplicationCommand {
+			return
+		}
+		ch, _ := robo.channels.Load(event.GuildID)
+		if ch == nil {
+			return
+		}
+		data := event.ApplicationCommandData()
+		if data.Name == "say" {
+			prompt := data.Options[0].StringValue()
+			response := robo.discordThink(ctx, ch.Learn, prompt)
+			_ = session.InteractionRespond(event.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content:         response,
+					AllowedMentions: nil,
+				},
+			})
+		} else if data.Name == "forget" {
+			prompt := data.Options[0].StringValue()
+			n := 64
+			messages := make([]brain.Message, n)
+			n, _, err := robo.brain.Recall(ctx, ch.Learn, "", messages)
+			if err != nil {
+				_ = session.InteractionRespond(event.Interaction, &discordgo.InteractionResponse{
+					Type: discordgo.InteractionResponseChannelMessageWithSource,
+					Data: &discordgo.InteractionResponseData{
+						Flags:           discordgo.MessageFlagsEphemeral,
+						Content:         err.Error(),
+						AllowedMentions: nil,
+					},
+				})
+				return
+			}
+			deleted := 0
+			for _, message := range messages {
+				if !strings.Contains(message.Text, prompt) {
+					continue
+				}
+				_ = robo.brain.Forget(ctx, ch.Learn, message.ID)
+				deleted++
+			}
+			_ = session.InteractionRespond(event.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Flags:           discordgo.MessageFlagsEphemeral,
+					Content:         "Deleted " + strconv.Itoa(deleted) + " messages from the database.",
+					AllowedMentions: nil,
+				},
+			})
+		}
+	})
+
+	return receiver, nil
+}
+
+func (robo *Robot) onDiscordMessage(ctx context.Context, session *discordgo.Session, event *discordgo.MessageCreate) {
+	// Ignore messages sent by bots
+	if event.Author.Bot {
+		return
+	}
+	log := slog.With(slog.String("trace", event.Message.ID), slog.String("in", event.GuildID))
+
+	// Find configuration for this server
+	ch, _ := robo.channels.Load(event.GuildID)
+	if ch == nil {
+		return
+	}
+
+	// If this is a blocked message we don't want to interact
+	if ch.Block.MatchString(event.Content) {
+		return
+	}
+
+	// Check for the channel being silent. This prevents learning, copypasta,
+	// and random speaking (among other things), which happens to be all the
+	// rest of this function.
+	if s := ch.SilentTime(); event.Timestamp.Before(s) {
+		log.DebugContext(ctx, "channel is silent", slog.Time("until", s))
+		return
+	}
+
+	// TODO: Learn from this user only if not disabled, not sure if applicable to discord
+	// TODO: Meme detector stuff, possibly not necessary in discord?
+	robo.discordLearn(ctx, ch.Learn, event)
+
+	// Now we can check rate limits
+	t := time.Now()
+	r := ch.Rate.ReserveN(t, 1)
+	if d := r.DelayFrom(t); d > 0 {
+		log.InfoContext(ctx, "rate limited",
+			slog.String("action", "speak"),
+			slog.String("delay", d.String()),
+		)
+		r.CancelAt(t)
+		return
+	}
+
+	// Attempt to handle textual commands
+	if strings.HasPrefix(event.Content, session.State.User.Mention()) {
+		// Message starts by mentioning robot
+		trimmed := strings.TrimSpace(strings.TrimPrefix(event.Content, session.State.User.Mention()))
+		parser := regexp.MustCompile(`^(?i:say|generate)\s*(?i:something)?\s*(?i:starting)?\s*(?i:with)?\s+(.*)`)
+		matches := parser.FindStringSubmatch(trimmed)
+		if matches != nil && len(matches) > 1 {
+			prompt := matches[1]
+			robo.discordSend(ctx, session, event.Message.Reference(), event.ChannelID, ch.Send, prompt)
+		} else {
+			robo.discordSend(ctx, session, event.Message.Reference(), event.ChannelID, ch.Send, "")
+		}
+		return
+	}
+
+	// Not rate limited and not a command so check for random message chance
+	if rand.Float64() > ch.Responses {
+		return
+	}
+	robo.discordSend(ctx, session, nil, event.ChannelID, ch.Send, "")
+}
+
+func (robo *Robot) discordSend(ctx context.Context, session *discordgo.Session, reference *discordgo.MessageReference, channelId string, tag string, prompt string) {
+	response := robo.discordThink(ctx, tag, prompt)
+	if response == "" {
+		return
+	}
+	message := &discordgo.MessageSend{
+		Content:         response,
+		AllowedMentions: nil,
+		Reference:       reference,
+	}
+	_, err := session.ChannelMessageSendComplex(
+		channelId,
+		message,
+	)
+	if err != nil {
+		_ = fmt.Errorf("failed to send discord message: %w", err)
+	}
+}
+
+func (robo *Robot) discordThink(ctx context.Context, tag string, prompt string) string {
+	m, _, err := brain.Think(ctx, robo.brain, tag, prompt)
+	if err != nil {
+		_ = fmt.Errorf("couldn't think: %w", err)
+		return ""
+	}
+	return m
+}
+
+func (robo *Robot) discordLearn(ctx context.Context, tag string, event *discordgo.MessageCreate) {
+	userHash := robo.hashes().Hash(event.Author.ID, event.GuildID, event.Timestamp)
+	message := brain.Message{
+		Sender:      userHash,
+		ID:          event.Message.ID,
+		To:          event.GuildID,
+		Text:        event.Content,
+		Timestamp:   event.Timestamp.UnixMilli(),
+		IsModerator: event.Member.Permissions&discordgo.PermissionManageMessages != 0,
+		IsElevated:  false, // TODO: Possibly some other flag?
+	}
+	err := brain.Learn(ctx, robo.brain, tag, &message)
+	if err != nil {
+		_ = fmt.Errorf("failed to learn message: %w", err)
+	}
+}
+
+// Start opens the Discord websocket connection.
+func (mr *MessageReceiver) Start() error {
+	return mr.session.Open()
+}
+
+// Close closes the Discord websocket connection.
+func (mr *MessageReceiver) Close() error {
+	return mr.session.Close()
+}

--- a/example.toml
+++ b/example.toml
@@ -71,8 +71,8 @@ meme = '^\S*$'
 # Currently, the only entry in it is twitch.
 [global.privileges]
 twitch = [
-	{ name = 'nightbot', level = 'ignore' },
-	{ name = 'streamelementsbot', level = 'ignore' },
+    { name = 'nightbot', level = 'ignore' },
+    { name = 'streamelementsbot', level = 'ignore' },
 ]
 
 [tmi]
@@ -134,7 +134,7 @@ meme = '^\S*$'
 # moderator privileges.
 # Unlike most strings, these are not expanded with environment variables.
 privileges = [
-	{ name = 'zephyrtronium', level = 'moderator' },
+    { name = 'zephyrtronium', level = 'moderator' },
 ]
 
 [twitch.bocchi.emotes]
@@ -142,3 +142,15 @@ privileges = [
 
 [twitch.bocchi.effects]
 'AAAAA' = 44444
+
+[discord]
+# Discord bot token, requires the Message Content intent enabled.
+token = ''
+# Server configurations, each server/guild must have a config section here
+# this is because we may want to learn from both twitch and discord
+# however only use discord messages in discord due to how pings are
+# formatted, emotes, etc...
+# Other parameters work the same way as the twitch configurations.
+configs = [
+    { server = "859946655310413844", learn = "bocchi", send = "bocchi", responses = 0.02, rate = { every = 10.1, num = 2 } }
+]

--- a/go.mod
+++ b/go.mod
@@ -23,11 +23,13 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bwmarrin/discordgo v0.28.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgraph-io/ristretto/v2 v2.0.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/flatbuffers v24.12.23+incompatible // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bwmarrin/discordgo v0.28.1 h1:gXsuo2GBO7NbR6uqmrrBDplPUx2T3nzu775q/Rd1aG4=
+github.com/bwmarrin/discordgo v0.28.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -55,6 +57,8 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
@@ -98,6 +102,7 @@ go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -114,6 +119,7 @@ golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
 golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -128,9 +134,11 @@ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=

--- a/main.go
+++ b/main.go
@@ -133,7 +133,13 @@ func cliRun(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	return robo.Run(ctx, cfg.HTTP.Listen)
+	if cfg.Discord.Token != "" {
+		if err := robo.SetDiscordChannels(cfg.Global, cfg.Discord); err != nil {
+			return err
+		}
+	}
+
+	return robo.Run(ctx, cfg.HTTP.Listen, cfg.Discord)
 }
 
 func cliSpeak(ctx context.Context, cmd *cli.Command) error {


### PR DESCRIPTION
I was having a chat with twin and this might be a fun (optional) addition, I saw you had a suggestion up for it on #7 so I gave it a shot. I'm a java guy not a golang guy so this is the best I could come up with and there's quite a lot of room for improvement.

This initial implementation should provide a means for robot to learn from a discord server as well as randomly post messages like she does in twitch, the configuration works in a slightly different way however. The idea was to be able to learn from both twitch and discord however only use the discord-learned messages on discord. It can also be setup to learn and work independently from twitch. It seems you kinda had that already with `Learn` and `Send` tags, im not exactly sure how they work but I implemented/used them for this.

I also implemented `say` and `forget` (slash) commands, she should also handle messages being deleted (by the user or a moderator).

To deploy/connect to Discord just create a bot and enable the `Message Content` intent as that's necessary to read message contents. If a token is not specified it doesn't enable any discord integrations. It's necessary to create a server configuration for each discord server she's gonna be in, I think it'd be better to put it on a table instead of the toml file but for now this should work.

Things you should probably check:
- Any exception handling fuckups that could cause a panic
- Any dependency/compilation issues that might have been introduced (idk how go.mod works)
- If my UserId/MessageId/UserHash handling makes sense at all

Things that could be improved:
- I have no clue how to work with the logger, Im sorry.
- Move all configs to a table?
- Implement an admin command to make robot shut up for a bit (or maybe dont and just timeout robot?)
- Implement a way to ban user ids globally or possibly per-server, should not be necessary but might be a nice addition
- Implement a way for users to opt-out from learning (privacy)
- Implement the copy-pasta feature
- Implement all your tracing for grafana, I'm not calling anything on this implementation for now
- Implement support for deferred messages on discord slash commands
- Implement a loop for that forget command...?

Things that are not necessary:
- No need to have an ignore channels config (just disable read perms on discord)
- No need to have a "dont talk here" config (just disable write perms on discord)
- Robot already ignores bots

Things that need to be looked into eventually:
- Meme detection (might not be necessary on discord?)
- Emote handling (it should just work:tm: but you never know??)
- Mention handling (it should work however messages are stored raw in the database so they are not usable for twitch, pings are disabled so she should `@` the user but not cause a notification)
- "haha funny" modes are not implemented (uwu, etc..)

Theres quite a lot of things that could be generalized/decoupled from the IRC client, such as learn and think calls to reduce all the duplicate code I ended up introducing with the discord methods. Generalizing some of the meme/copypasta/block/trace and other similar things could also go a long way now that this exists.

I'm assuming that to your golang eyes this is garbo code (I have no clue how that `robo *Robot` parameter gets passed around) so feel free to tell me what to fix or do any changes you feel are fit. You can also message me on discord if you want to go over anything. I did test this so the bare minimum works.