### PR TITLE
update dockerfile to use the proper golang image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # docker build -t robot 
 
 # Main image
-FROM golang:1.23-alpine AS build
+FROM golang:1.26-alpine AS build
 
 # Populate Go resources
 COPY go.mod go.sum ./


### PR DESCRIPTION
Bumping the Docker golang version to 1.26, 1.23 is no longer supported